### PR TITLE
Add support for Facebook AppSecret-Proof, bump version to v0.1.5

### DIFF
--- a/lib/passport-facebook-token/strategy.js
+++ b/lib/passport-facebook-token/strategy.js
@@ -2,6 +2,8 @@
  * Module dependencies.
  */
 var util = require('util')
+  , uri = require('url')
+  , crypto = require('crypto')
   , OAuth2Strategy = require('passport-oauth').OAuth2Strategy
   , InternalOAuthError = require('passport-oauth').InternalOAuthError;
 
@@ -49,6 +51,8 @@ function FacebookTokenStrategy(options, verify) {
   OAuth2Strategy.call(this, options, verify);
   this._profileURL = options.profileURL || 'https://graph.facebook.com/me';
   this.name = 'facebook-token';
+  this._clientSecret = options.clientSecret;
+  this._enableProof = options.enableProof;
 }
 
 /**
@@ -140,7 +144,20 @@ FacebookTokenStrategy.prototype.authorizationParams = function (options) {
  * @api protected
  */
 FacebookTokenStrategy.prototype.userProfile = function(accessToken, done) {
-  var url = this._profileURL;
+  var url = uri.parse(this._profileURL);
+  if (this._enableProof) {
+    // Secure API call by adding proof of the app secret.  This is required when
+    // the "Require AppSecret Proof for Server API calls" setting has been
+    // enabled.  The proof is a SHA256 hash of the access token, using the app
+    // secret as the key.
+    //
+    // For further details, refer to:
+    // https://developers.facebook.com/docs/reference/api/securing-graph-api/    
+    var proof = crypto.createHmac('sha256', this._clientSecret).update(accessToken).digest('hex');
+    url.search = (url.search ? url.search + '&' : '') + 'appsecret_proof=' + encodeURIComponent(proof);
+  }
+  url = uri.format(url);
+
   this._oauth2.getProtectedResource(url, accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-facebook-token",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Facebook token authentication strategy for Passport.",
   "author": { "name": "Nicholas Penree", "email": "nick@penree.com", "url": "http://www.penree.com/" },
   "repository": {


### PR DESCRIPTION
See [https://developers.facebook.com/docs/reference/api/securing-graph-api/](https://developers.facebook.com/docs/reference/api/securing-graph-api/)] and [https://github.com/jaredhanson/passport-facebook/issues/62](https://github.com/jaredhanson/passport-facebook/issues/62) for more details.

This pull request includes a clone of the support added to the facebook-token package. Let me know if you have any questions - thanks!
