### PR TITLE
Adding support for profileFields and mapping of picture field to profile

### DIFF
--- a/lib/passport-facebook-token/strategy.js
+++ b/lib/passport-facebook-token/strategy.js
@@ -53,6 +53,7 @@ function FacebookTokenStrategy(options, verify) {
   this.name = 'facebook-token';
   this._clientSecret = options.clientSecret;
   this._enableProof = options.enableProof;
+  this._profileFields = options.profileFields || null;
 }
 
 /**
@@ -156,6 +157,10 @@ FacebookTokenStrategy.prototype.userProfile = function(accessToken, done) {
     var proof = crypto.createHmac('sha256', this._clientSecret).update(accessToken).digest('hex');
     url.search = (url.search ? url.search + '&' : '') + 'appsecret_proof=' + encodeURIComponent(proof);
   }
+  if (this._profileFields) {
+    var fields = this._convertProfileFields(this._profileFields);
+    if (fields !== '') { url.search = (url.search ? url.search + '&' : '') + 'fields=' + fields; }
+  }
   url = uri.format(url);
 
   this._oauth2.getProtectedResource(url, accessToken, function (err, body, res) {
@@ -174,6 +179,15 @@ FacebookTokenStrategy.prototype.userProfile = function(accessToken, done) {
       profile.gender = json.gender;
       profile.profileUrl = json.link;
       profile.emails = [{ value: json.email }];
+
+      if (json.picture) {
+        if (typeof json.picture == 'object' && json.picture.data) {
+          // October 2012 Breaking Changes
+          profile.photos = [{ value: json.picture.data.url }];
+        } else {
+          profile.photos = [{ value: json.picture }];
+        }
+      }
       
       profile._raw = body;
       profile._json = json;
@@ -215,6 +229,33 @@ FacebookTokenStrategy.prototype._loadUserProfile = function(accessToken, done) {
     return skipIt();
   }
 }
+
+FacebookTokenStrategy.prototype._convertProfileFields = function(profileFields) {
+  var map = {
+    'id':          'id',
+    'username':    'username',
+    'displayName': 'name',
+    'name':       ['last_name', 'first_name', 'middle_name'],
+    'gender':      'gender',
+    'profileUrl':  'link',
+    'emails':      'email',
+    'photos':      'picture'
+  };
+  
+  var fields = [];
+  
+  profileFields.forEach(function(f) {
+    if (typeof map[f] === 'undefined') { return; }
+
+    if (Array.isArray(map[f])) {
+      Array.prototype.push.apply(fields, map[f]);
+    } else {
+      fields.push(map[f]);
+    }
+  });
+
+  return fields.join(',');
+};
 
 
 /**


### PR DESCRIPTION
I have added support for the profileFields option that is available in the passport-facebook strategy.  In addition, I have added support for the picture field of the profile to be consistent with the passport-facebook strategy.

Please merge this code with the master branch.

Thanks,
Phil
