### PR TITLE
allow req.body to be undefined but fail if token not located in querystring

### DIFF
--- a/lib/passport-facebook-token/strategy.js
+++ b/lib/passport-facebook-token/strategy.js
@@ -78,12 +78,19 @@ FacebookTokenStrategy.prototype.authenticate = function(req, options) {
     return this.fail();
   }
   
-  if (!req.body) {
-    return this.fail();
+  // req.body may not be present, but token may be present in querystring
+  var accessToken,refreshToken;
+  if(req.body){
+	  accessToken = req.body.access_token;
+	  refreshToken = eq.body.refresh_token;
   }
   
-  var accessToken = req.body.access_token || req.query.access_token;
-  var refreshToken = req.body.refresh_token || req.query.refresh_token;
+  accessToken = accessToken || req.query.access_token;
+  refreshToken = refreshToken || req.query.refresh_token;
+  
+  if (!accessToken) {
+	  return this.fail();
+  }
   
   self._loadUserProfile(accessToken, function(err, profile) {
     if (err) { return self.fail(err); };


### PR DESCRIPTION
The commits checks to see if the req.body is defined.  If it is it attempts to retrieve access_token and refresh_token from the body.  If access and refresh tokens are still undefined then pull from querystring.  Finally, if access token is still undefined then fail to avoid trip to facebook with empty token.
