### PR TITLE
Changed `self.fail` to `self.error` for `self._loadUserProfile`

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ FacebookTokenStrategy.prototype.authenticate = function(req, options) {
   }
 
   self._loadUserProfile(accessToken, function(error, profile) {
-    if (error) return self.fail(error);
+    if (error) return self.error(error);
 
     function verified(error, user, info) {
       if (error) return self.error(error);


### PR DESCRIPTION
Basically I kept getting a `401` unauthorized error response with a message "Unauthorized" (e.g. a typical `AuthenticationError` type`).

After placing a `console.log(error)` [here](https://github.com/drudge/passport-facebook-token/blob/master/index.js#L78) I was able to trace the real error message that was occurring (e.g. `Cannot set property 'id' of undefined`).