### PR TITLE
Added configurable versioning info in all graph URLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,22 +27,25 @@ export default class FacebookTokenStrategy extends OAuth2Strategy {
   constructor(_options, _verify) {
     const options = _options || {};
     const verify = _verify;
+	const _fbGraphVersion = options.fbGraphVersion || 'v2.6';
+	
 
-    options.authorizationURL = options.authorizationURL || 'https://www.facebook.com/v2.4/dialog/oauth';
-    options.tokenURL = options.tokenURL || 'https://graph.facebook.com/oauth/access_token';
+    options.authorizationURL = options.authorizationURL || `https://www.facebook.com/${_fbGraphVersion}/dialog/oauth`;
+    options.tokenURL = options.tokenURL || `https://graph.facebook.com/${_fbGraphVersion}/oauth/access_token`;
 
     super(options, verify);
 
     this.name = 'facebook-token';
     this._accessTokenField = options.accessTokenField || 'access_token';
     this._refreshTokenField = options.refreshTokenField || 'refresh_token';
-    this._profileURL = options.profileURL || 'https://graph.facebook.com/v2.4/me';
+    this._profileURL = options.profileURL || `https://graph.facebook.com/${_fbGraphVersion}/me`;
     this._profileFields = options.profileFields || ['id', 'displayName', 'name', 'emails'];
     this._profileImage = options.profileImage || {};
     this._clientSecret = options.clientSecret;
     this._enableProof = typeof options.enableProof === 'boolean' ? options.enableProof : true;
     this._passReqToCallback = options.passReqToCallback;
     this._oauth2.useAuthorizationHeaderforGET(false);
+	this._fbGraphVersion = _fbGraphVersion;
   }
 
   /**
@@ -117,7 +120,7 @@ export default class FacebookTokenStrategy extends OAuth2Strategy {
         const json = JSON.parse(body);
 
         // Get image URL based on profileImage options
-        let imageUrl = uri.parse(`https://graph.facebook.com/${json.id}/picture`);
+        let imageUrl = uri.parse(`https://graph.facebook.com/${this._fbGraphVersion}/${json.id}/picture`);
         if (this._profileImage.width) imageUrl.search = `width=${this._profileImage.width}`;
         if (this._profileImage.height) imageUrl.search = `${imageUrl.search ? imageUrl.search + '&' : ''}height=${this._profileImage.height}`;
         imageUrl.search = `${imageUrl.search ? imageUrl.search : 'type=large'}`;

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export default class FacebookTokenStrategy extends OAuth2Strategy {
   constructor(_options, _verify) {
     const options = _options || {};
     const verify = _verify;
-	const _fbGraphVersion = options.fbGraphVersion || 'v2.6';
+    const _fbGraphVersion = options.fbGraphVersion || 'v2.6';
 	
 
     options.authorizationURL = options.authorizationURL || `https://www.facebook.com/${_fbGraphVersion}/dialog/oauth`;
@@ -45,7 +45,7 @@ export default class FacebookTokenStrategy extends OAuth2Strategy {
     this._enableProof = typeof options.enableProof === 'boolean' ? options.enableProof : true;
     this._passReqToCallback = options.passReqToCallback;
     this._oauth2.useAuthorizationHeaderforGET(false);
-	this._fbGraphVersion = _fbGraphVersion;
+    this._fbGraphVersion = _fbGraphVersion;
   }
 
   /**

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -25,6 +25,27 @@ describe('FacebookTokenStrategy:init', () => {
   it('Should properly throw exception when options is empty', () => {
     assert.throw(() => new FacebookTokenStrategy(), Error);
   });
+  
+  it('Should use the default fb graph version when no explicit version is specified', () => {
+  	let strategy = new FacebookTokenStrategy(STRATEGY_CONFIG, BLANK_FUNCTION);
+	assert.equal(strategy._fbGraphVersion, 'v2.6');
+    assert.equal(strategy._oauth2._accessTokenUrl,'https://graph.facebook.com/v2.6/oauth/access_token');
+    assert.equal(strategy._oauth2._authorizeUrl,'https://www.facebook.com/v2.6/dialog/oauth');
+    assert.equal(strategy._profileURL,'https://graph.facebook.com/v2.6/me');
+  });
+  
+  it('Should use the explicit version, if specified', () => {
+	let strategy = new FacebookTokenStrategy({
+  	  clientID: '123',
+  	  clientSecret: '123',
+	  fbGraphVersion: 'v2.4'
+	}, BLANK_FUNCTION);
+	assert.equal(strategy._fbGraphVersion, 'v2.4');  
+    assert.equal(strategy._oauth2._accessTokenUrl,'https://graph.facebook.com/v2.4/oauth/access_token');
+    assert.equal(strategy._oauth2._authorizeUrl,'https://www.facebook.com/v2.4/dialog/oauth');
+    assert.equal(strategy._profileURL,'https://graph.facebook.com/v2.4/me');	
+  });
+  
 });
 
 describe('FacebookTokenStrategy:authenticate', () => {
@@ -295,7 +316,7 @@ describe('FacebookTokenStrategy:userProfile', () => {
       assert.equal(profile.name.givenName, 'Eugene');
       assert.equal(profile.gender, 'male');
       assert.equal(profile.emails[0].value, 'ghaiklor@gmail.com');
-      assert.equal(profile.photos[0].value, 'https://graph.facebook.com/794955667239296/picture?type=large');
+      assert.equal(profile.photos[0].value, 'https://graph.facebook.com/v2.6/794955667239296/picture?type=large');
       assert.equal(typeof profile._raw, 'string');
       assert.equal(typeof profile._json, 'object');
 
@@ -328,7 +349,7 @@ describe('FacebookTokenStrategy:userProfile', () => {
     sinon.stub(strategy._oauth2, 'get', (url, accessToken, next) => next(null, fakeProfile, null));
 
     strategy.userProfile('accessToken', (error, profile) => {
-      assert.equal(strategy._oauth2.get.getCall(0).args[0], 'https://graph.facebook.com/v2.4/me?appsecret_proof=8c340bd01643ab69939ca971314d7a3d64bfb18946cdde566f12fdbf6707d182&fields=id,name,last_name,first_name,middle_name,email');
+      assert.equal(strategy._oauth2.get.getCall(0).args[0], 'https://graph.facebook.com/v2.6/me?appsecret_proof=8c340bd01643ab69939ca971314d7a3d64bfb18946cdde566f12fdbf6707d182&fields=id,name,last_name,first_name,middle_name,email');
       strategy._oauth2.get.restore();
       done();
     });
@@ -344,7 +365,7 @@ describe('FacebookTokenStrategy:userProfile', () => {
     sinon.stub(strategy._oauth2, 'get', (url, accessToken, next) => next(null, fakeProfile, null));
 
     strategy.userProfile('accessToken', (error, profile) => {
-      assert.equal(strategy._oauth2.get.getCall(0).args[0], 'https://graph.facebook.com/v2.4/me?appsecret_proof=8c340bd01643ab69939ca971314d7a3d64bfb18946cdde566f12fdbf6707d182&fields=last_name,first_name,middle_name,custom');
+      assert.equal(strategy._oauth2.get.getCall(0).args[0], 'https://graph.facebook.com/v2.6/me?appsecret_proof=8c340bd01643ab69939ca971314d7a3d64bfb18946cdde566f12fdbf6707d182&fields=last_name,first_name,middle_name,custom');
       strategy._oauth2.get.restore();
       done();
     });
@@ -377,7 +398,7 @@ describe('FacebookTokenStrategy:userProfile', () => {
     strategy.userProfile('accessToken', (error, profile) => {
       if (error) return done(error);
 
-      assert.equal(profile.photos[0].value, 'https://graph.facebook.com/794955667239296/picture?width=1520&height=1520');
+      assert.equal(profile.photos[0].value, 'https://graph.facebook.com/v2.6/794955667239296/picture?width=1520&height=1520');
 
       strategy._oauth2.get.restore();
       done();

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -27,20 +27,20 @@ describe('FacebookTokenStrategy:init', () => {
   });
   
   it('Should use the default fb graph version when no explicit version is specified', () => {
-  	let strategy = new FacebookTokenStrategy(STRATEGY_CONFIG, BLANK_FUNCTION);
-	assert.equal(strategy._fbGraphVersion, 'v2.6');
+    let strategy = new FacebookTokenStrategy(STRATEGY_CONFIG, BLANK_FUNCTION);
+    assert.equal(strategy._fbGraphVersion, 'v2.6');
     assert.equal(strategy._oauth2._accessTokenUrl,'https://graph.facebook.com/v2.6/oauth/access_token');
     assert.equal(strategy._oauth2._authorizeUrl,'https://www.facebook.com/v2.6/dialog/oauth');
     assert.equal(strategy._profileURL,'https://graph.facebook.com/v2.6/me');
   });
   
   it('Should use the explicit version, if specified', () => {
-	let strategy = new FacebookTokenStrategy({
-  	  clientID: '123',
-  	  clientSecret: '123',
-	  fbGraphVersion: 'v2.4'
-	}, BLANK_FUNCTION);
-	assert.equal(strategy._fbGraphVersion, 'v2.4');  
+    let strategy = new FacebookTokenStrategy({
+      clientID: '123',
+      clientSecret: '123',
+      fbGraphVersion: 'v2.4'
+    }, BLANK_FUNCTION);
+    assert.equal(strategy._fbGraphVersion, 'v2.4');  
     assert.equal(strategy._oauth2._accessTokenUrl,'https://graph.facebook.com/v2.4/oauth/access_token');
     assert.equal(strategy._oauth2._authorizeUrl,'https://www.facebook.com/v2.4/dialog/oauth');
     assert.equal(strategy._profileURL,'https://graph.facebook.com/v2.4/me');	


### PR DESCRIPTION
In order to possibly address issue  #55 a new option called `fbGraphVersion` can be passed in the constructor to control the version of the API used by the package, e.g. to use version 2.4 the options field would look like:
    {
      clientID: '123',
      clientSecret: '123',
      fbGraphVersion: 'v2.4'
    }
The version (a string parameter) is used to construct the `tokenURL`, the `authorizationURL` and other URLs used by the package. Explicitly specifying those URLs in the options parameter effectively bypasses the `fbGraphVersion` parameter.

I have put the newest one (2.6) as default, but feel free to change the default value to something else. 

There are two new test cases to verify the new functionality. They use `_oauth2` internal properties to verify that the correct URLs have been passed to the invocation of super in `FacebookTokenStrategy` constructor, which may result in the tests being brittle to changes in OAuth2 package. Another options would be to duplicate existing test case where the `_oauth2.get` is stubbed out to verify that the correct URL is used in both case when `fbGraphVersion` is explicitly or implicitly specified.