### PR TITLE
Update default graph-version to latest (v2.10)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,8 @@ export default class FacebookTokenStrategy extends OAuth2Strategy {
   constructor(_options, _verify) {
     const options = _options || {};
     const verify = _verify;
-    const _fbGraphVersion = options.fbGraphVersion || 'v2.6';
+    const _fbGraphVersion = options.fbGraphVersion || 'v2.10';
 	
-
     options.authorizationURL = options.authorizationURL || `https://www.facebook.com/${_fbGraphVersion}/dialog/oauth`;
     options.tokenURL = options.tokenURL || `https://graph.facebook.com/${_fbGraphVersion}/oauth/access_token`;
 


### PR DESCRIPTION
The latest Facebook Graph-API version is v2.10.0 which would be awesome to have as the default value here. Thanks!